### PR TITLE
Skip unit tests when extension not available, improve autoload

### DIFF
--- a/tests/ContainMapper/Driver/Memcached/ConnectionTest.php
+++ b/tests/ContainMapper/Driver/Memcached/ConnectionTest.php
@@ -6,6 +6,16 @@ use Memcached as PHPMemcached;
 
 class ConnectionTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function setUp()
+    {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped(
+                'The Memcached extension is not available.'
+            );
+        }
+    }
+
     public function testConstruct()
     {
         $memcached = new PHPMemcached();

--- a/tests/ContainMapper/Driver/Memcached/DriverTest.php
+++ b/tests/ContainMapper/Driver/Memcached/DriverTest.php
@@ -13,6 +13,12 @@ class DriverTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped(
+                'The Memcached extension is not available.'
+            );
+        }
+
         $memcached = new PHPMemcached();
         $memcached->addServer('127.0.0.1', 11211);
         $memcached->setOption(PHPMemcached::OPT_PREFIX_KEY, (string) microtime(true)); // sandbox the test

--- a/tests/ContainMapper/Driver/MongoDB/ConnectionTest.php
+++ b/tests/ContainMapper/Driver/MongoDB/ConnectionTest.php
@@ -6,6 +6,16 @@ use Mongo;
 
 class Test extends \PHPUnit_Framework_TestCase
 {
+
+    public function setUp()
+    {
+        if (!extension_loaded('mongo')) {
+            $this->markTestSkipped(
+                'The Mongo extension is not available.'
+            );
+        }
+    }
+
     public function testConstruct()
     {
         $db = new Mongo('mongodb://127.0.0.1');

--- a/tests/ContainMapper/Driver/MongoDB/DriverTest.php
+++ b/tests/ContainMapper/Driver/MongoDB/DriverTest.php
@@ -13,6 +13,12 @@ class DriverTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('mongo')) {
+            $this->markTestSkipped(
+                'The Mongo extension is not available.'
+            );
+        }
+
         $db = new Mongo('mongodb://127.0.0.1');
         $db->test->test->drop();
         $connection = new \ContainMapper\Driver\MongoDB\Connection($db, 'test', 'test');

--- a/tests/ContainMapper/MapperTest.php
+++ b/tests/ContainMapper/MapperTest.php
@@ -11,6 +11,12 @@ class MapperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!extension_loaded('mongo')) {
+            $this->markTestSkipped(
+                'The Mongo extension is not available.'
+            );
+        }
+
         $db = new Mongo('mongodb://127.0.0.1');
         $db->test->test->drop();
         $connection = new \ContainMapper\Driver\MongoDB\Connection($db, 'test', 'test');

--- a/tests/_autoload.php
+++ b/tests/_autoload.php
@@ -2,21 +2,23 @@
 /**
  * Setup autoloading
  */
-if (file_exists(__DIR__ . '/../../../autoload.php')) {
-    include_once __DIR__ . '/../../../autoload.php';
+$loader = array(
+    'Contain'           => __DIR__ . '/../../contain/src/Contain',
+    'ContainTest'       => __DIR__ . '/../../contain/tests/Contain',
+    'ContainMapperTest' => __DIR__ . '/ContainMapper',
+    'ContainMapper'     => __DIR__ . '/../src/ContainMapper',
+);
+
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
 } else {
     // if composer autoloader is missing, explicitly load the standard
     // autoloader by relativepath
     require_once __DIR__ . '/../../../zendframework/zendframework/library/Zend/Loader/StandardAutoloader.php';
+    $loader['Zend'] = __DIR__ . '/../../../zendframework/zendframework/library/Zend';
 }
 
 $loader = new Zend\Loader\StandardAutoloader(array(
-    Zend\Loader\StandardAutoloader::LOAD_NS => array(
-        'Zend'              => __DIR__ . '/../../../zendframework/zendframework/library/Zend',
-        'Contain'           => __DIR__ . '/../../contain/src/Contain',
-        'ContainTest'       => __DIR__ . '/../../contain/tests/Contain',
-        'ContainMapperTest' => __DIR__ . '/ContainMapper',
-        'ContainMapper'     => __DIR__ . '/../src/ContainMapper',
-    ),
+    Zend\Loader\StandardAutoloader::LOAD_NS => $loader,
 ));
 $loader->register();


### PR DESCRIPTION
- Skips the MongoDB related tests if the mongo extension is not loaded.
- Skips the Memcached related tests if the memcached extension is not loaded.
- Updates autoloading support to be nicer and make use of the vendor folder when avail.
