### PR TITLE
DriverInterface & AbstractDriver missing hydrate method

### DIFF
--- a/src/ContainMapper/Driver/AbstractDriver.php
+++ b/src/ContainMapper/Driver/AbstractDriver.php
@@ -67,6 +67,18 @@ abstract class AbstractDriver
     }
 
     /**
+     * Post-hydration callback.
+     *
+     * @param   Contain\Entity\EntityInterface
+     * @param   Values we returned
+     * @return  $this
+     */
+    public function hydrate(EntityInterface $entity, $values)
+    {
+        return $this;
+    }
+
+    /**
      * Returns true if the data entity has been persisted to the data store
      * this driver is responsible for.
      *

--- a/src/ContainMapper/Driver/DriverInterface.php
+++ b/src/ContainMapper/Driver/DriverInterface.php
@@ -32,6 +32,15 @@ use Contain\Entity\EntityInterface;
 interface DriverInterface
 {
     /**
+     * Post-hydration callback.
+     *
+     * @param   Contain\Entity\EntityInterface
+     * @param   Values we returned
+     * @return  $this
+     */
+    public function hydrate(EntityInterface $entity, $values);
+
+    /**
      * Returns true if the data entity has been persisted to the data store
      * this driver is responsible for.
      *

--- a/src/ContainMapper/Driver/File/Driver.php
+++ b/src/ContainMapper/Driver/File/Driver.php
@@ -139,16 +139,4 @@ class Driver extends ContainMapper\Driver\AbstractDriver
 
         return $this;
     }
-
-    /**
-     * Post-hydration callback.
-     *
-     * @param   Contain\Entity\EntityInterface
-     * @param   Values we returned
-     * @return  $this
-     */
-    public function hydrate(EntityInterface $entity, $values)
-    {
-        return $this;
-    }
 }

--- a/src/ContainMapper/Driver/Memcached/Driver.php
+++ b/src/ContainMapper/Driver/Memcached/Driver.php
@@ -120,16 +120,4 @@ class Driver extends ContainMapper\Driver\AbstractDriver
 
         return $results;
     }
-
-    /**
-     * Post-hydration callback.
-     *
-     * @param   Contain\Entity\EntityInterface
-     * @param   Values we returned
-     * @return  $this
-     */
-    public function hydrate(EntityInterface $entity, $values)
-    {
-        return $this;
-    }
 }


### PR DESCRIPTION
DriverInterface was missing hydrate method, also the abstract class should have had the hydrate method with the default behavior that was duplicated in the file and memcached drivers.

This was one of the only things that was causing some issues with the new Zend Db Tablegateway integration :)
