### PR TITLE
Zend\Db\TableGateway\TableGateway Addition of Select Criteria

### DIFF
--- a/src/ContainMapper/Driver/ZendDb/Driver.php
+++ b/src/ContainMapper/Driver/ZendDb/Driver.php
@@ -196,7 +196,7 @@ class Driver extends AbstractDriver
      */
     public function count(array $criteria)
     {
-        $resultSet = $this->tableGateway->select($this->criteria($criteria));
+        $resultSet = $this->tableGateway->selectWith($this->criteria($criteria));
         return $resultSet->count();
     }
 
@@ -228,7 +228,7 @@ class Driver extends AbstractDriver
         $select = $this->criteria($criteria);
         $select->limit(1);
 
-        $result = $this->tableGateway->select($select);
+        $result = $this->tableGateway->selectWith($select);
 
         if (!$result) {
             return false;


### PR DESCRIPTION
This PR adds some special handling to the criteria for such things as count, find and findOne to allow for the ability to utilize the different selectors.  

Consider this just some initial handling (since it will be easy to change and internal only).  I just need something for the short-term and would like to add more property checking type things in the future to it.
