### PR TITLE
Zend Db Method Handling

### DIFF
--- a/src/ContainMapper/Driver/ZendDb/Driver.php
+++ b/src/ContainMapper/Driver/ZendDb/Driver.php
@@ -269,7 +269,7 @@ class Driver extends AbstractDriver
 
         $isSpecial = false;
         foreach ($criteria as $k => $v) {
-            if (in_array($k, $this->selectCriteria)) {
+            if (in_array($k, $this->selectCriteria, true)) {
                 $isSpecial = true;
                 break;
             }


### PR DESCRIPTION
Currently there is an issue on the in_array function where we do not have strict matching.  This causes simple things like:

findOne(array('foo = 0')) to trigger special mode which we obviously do not want :)
