### PR TITLE
Fix ZendDb Driver when handling Updates with Child or List Entities

### DIFF
--- a/src/ContainMapper/Driver/ZendDb/Driver.php
+++ b/src/ContainMapper/Driver/ZendDb/Driver.php
@@ -178,10 +178,10 @@ class Driver extends AbstractDriver
             if (!$primary) {
                 return false;
             }
-            $this->tableGateway->update(
-                $data = $this->getUpdateCriteria($entity),
-                $primary
-            );
+            $data = $this->getUpdateCriteria($entity);
+            if ($data) {
+                $this->tableGateway->update($data, $primary);
+            }
         }
 
         return $this;


### PR DESCRIPTION
Resolved an issue where there was child entities that would be dirty but no other dirty items causing the update statement to fail.
