### PR TITLE
Resolve Dependency Issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,11 @@
         "irc": "irc://irc.freenode.net/contain"
     },
     "require": {
+        "zendframework/zend-eventmanager:: "~2.2",
         "php": ">=5.3.3"
     },
     "suggest": {
-        "zendframework/zendframework": "~2.0",
+        "zendframework/zend-db": "~2.2",
         "akandels/contain": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
- AbstractService requires zend event manager and should be a requirement
- Instead of suggesting the entire ZF2 stack, zend-db is an optional requirement
