### PR TITLE
Resolved PDO non-autoincrementing id issue

### DIFF
--- a/src/ContainMapper/Driver/PDO/Driver.php
+++ b/src/ContainMapper/Driver/PDO/Driver.php
@@ -545,10 +545,14 @@ class Driver extends ContainMapper\Driver\AbstractDriver
             ->prepare($sql)
             ->execute($this->params);
 
-        $entity->setExtendedProperty('_id', $db->lastInsertId());
+        if ($id = $db->lastInsertId()) {
+            $entity->setExtendedProperty('_id', $db->lastInsertId());
 
-        if (($primary = $entity->primary()) && count($primary) == 1) {
-            $entity->set(implode('', array_slice(array_keys($primary), 0, 1)), $entity->getExtendedProperty('_id'));
+            if (($primary = $entity->primary()) && count($primary) == 1) {
+                $entity->set(implode('', array_slice(array_keys($primary), 0, 1)), $entity->getExtendedProperty('_id'));
+            }
+        } elseif (($primary = $entity->primary()) && count($primary) == 1) {
+            $entity->setExtendedProperty('_id', array_shift($primary));
         }
 
         return $this;


### PR DESCRIPTION
If you have a table that has a primary key that is not an auto incrementing id the id column will be unset and improperly handled by the mapper thus leaving your entity in an odd state.  This causes massive issues when you have other inserts relying on the value of the primary inside of the same process.
